### PR TITLE
Add `Transpose` operator

### DIFF
--- a/microflow-macros/src/lib.rs
+++ b/microflow-macros/src/lib.rs
@@ -145,6 +145,7 @@ pub fn model(args: TokenStream, item: TokenStream) -> TokenStream {
             BuiltinOperator::AVERAGE_POOL_2D => average_pool_2d::parse(operator, tensors),
             BuiltinOperator::SOFTMAX => softmax::parse(operator, tensors),
             BuiltinOperator::RESHAPE => Box::new(reshape::parse(operator, tensors)),
+            BuiltinOperator::TRANSPOSE => transpose::parse(operator, tensors, buffers),
             unsupported_op => abort_call_site!("unsupported operator: {:?}", unsupported_op),
         };
         layer.to_tokens(&mut layers)

--- a/microflow-macros/src/ops/mod.rs
+++ b/microflow-macros/src/ops/mod.rs
@@ -4,3 +4,4 @@ pub(crate) mod depthwise_conv_2d;
 pub(crate) mod fully_connected;
 pub(crate) mod reshape;
 pub(crate) mod softmax;
+pub(crate) mod transpose;

--- a/microflow-macros/src/ops/transpose.rs
+++ b/microflow-macros/src/ops/transpose.rs
@@ -1,0 +1,130 @@
+use std::mem::size_of;
+
+use crate::tflite_flatbuffers::tflite::{Buffer, Operator, Tensor, TensorType};
+use flatbuffers::{ForwardsUOffset, Vector};
+use proc_macro2::TokenStream as TokenStream2;
+use proc_macro_error::abort_call_site;
+use quote::{quote, ToTokens};
+
+/// Parsed TFLite `Transpose`: input tensor + `perm` (INT32 buffer).
+pub(crate) struct TokenTranspose {
+    pub(crate) perm: Vec<usize>,
+    pub(crate) output_shape: Vec<usize>,
+}
+
+pub(crate) fn parse(
+    operator: Operator,
+    tensors: Vector<ForwardsUOffset<Tensor>>,
+    buffers: Vector<ForwardsUOffset<Buffer>>,
+) -> Box<dyn ToTokens> {
+    Box::new(TokenTranspose::new(operator, tensors, buffers))
+}
+
+fn read_i32_perm(tensor: Tensor, buffers: Vector<ForwardsUOffset<Buffer>>) -> Vec<i32> {
+    let data = buffers
+        .get(tensor.buffer() as usize)
+        .data()
+        .unwrap_or_else(|| abort_call_site!("transpose: missing perm buffer"))
+        .bytes();
+    data.chunks_exact(size_of::<i32>())
+        .map(|c| i32::from_le_bytes(c.try_into().unwrap()))
+        .collect()
+}
+
+impl TokenTranspose {
+    pub(crate) fn new(
+        operator: Operator,
+        tensors: Vector<ForwardsUOffset<Tensor>>,
+        buffers: Vector<ForwardsUOffset<Buffer>>,
+    ) -> Self {
+        let inputs = operator
+            .inputs()
+            .unwrap_or_else(|| abort_call_site!("transpose: no inputs"));
+        if inputs.len() < 2 {
+            abort_call_site!("transpose requires two inputs (data, perm)");
+        }
+        let perm_tensor = tensors.get(inputs.get(1) as usize);
+        if perm_tensor.type_() != TensorType::INT32 {
+            abort_call_site!("transpose perm tensor must be INT32");
+        }
+        let perm_i32 = read_i32_perm(perm_tensor, buffers);
+        let perm: Vec<usize> = perm_i32.iter().map(|&p| p as usize).collect();
+
+        let mut output_shape: Vec<_> = tensors
+            .get(operator.outputs().unwrap().get(0) as usize)
+            .shape()
+            .unwrap()
+            .iter()
+            .map(|e| e as usize)
+            .collect();
+        if output_shape.len() == 1 {
+            output_shape.insert(0, 1);
+        }
+
+        let rank = output_shape.len();
+        if perm.len() != rank {
+            abort_call_site!("transpose perm length must match tensor rank");
+        }
+
+        Self { perm, output_shape }
+    }
+}
+
+impl ToTokens for TokenTranspose {
+    fn to_tokens(&self, tokens: &mut TokenStream2) {
+        let perm = &self.perm;
+        let output_shape = &self.output_shape;
+        let rank = output_shape.len();
+
+        let ts = match rank {
+            2 => quote! {
+                let input: microflow::tensor::Tensor2D<_, #(#output_shape),*, 1usize> =
+                    microflow::ops::transpose_2d(input, [#(#perm),*]);
+            },
+            4 => quote! {
+                let input: microflow::tensor::Tensor4D<_, #(#output_shape),*, 1usize> =
+                    microflow::ops::transpose_4d(input, [#(#perm),*]);
+            },
+            _ => abort_call_site!("transpose: only rank 2 and 4 are supported"),
+        };
+        ts.to_tokens(tokens);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use quote::ToTokens;
+
+    #[test]
+    fn token_transpose_to_tokens_2d() {
+        let layer = TokenTranspose {
+            perm: vec![1, 0],
+            output_shape: vec![3, 2],
+        };
+        assert_eq!(
+            layer.to_token_stream().to_string(),
+            quote! {
+                let input: microflow::tensor::Tensor2D<_, 3usize, 2usize, 1usize> =
+                    microflow::ops::transpose_2d(input, [1usize, 0usize]);
+            }
+            .to_string()
+        );
+    }
+
+    #[test]
+    fn token_transpose_to_tokens_4d() {
+        let layer = TokenTranspose {
+            perm: vec![0, 1, 3, 2],
+            output_shape: vec![1, 2, 2, 3],
+        };
+        assert_eq!(
+            layer.to_token_stream().to_string(),
+            quote! {
+                let input: microflow::tensor::Tensor4D<_, 1usize, 2usize, 2usize, 3usize, 1usize> =
+                    microflow::ops::transpose_4d(input, [0usize, 1usize, 3usize, 2usize]);
+            }
+            .to_string()
+        );
+    }
+}

--- a/src/ops/mod.rs
+++ b/src/ops/mod.rs
@@ -4,6 +4,7 @@ mod depthwise_conv_2d;
 mod fully_connected;
 mod reshape;
 mod softmax;
+mod transpose;
 
 pub use average_pool_2d::*;
 pub use conv_2d::*;
@@ -11,3 +12,4 @@ pub use depthwise_conv_2d::*;
 pub use fully_connected::*;
 pub use reshape::*;
 pub use softmax::*;
+pub use transpose::*;

--- a/src/ops/transpose.rs
+++ b/src/ops/transpose.rs
@@ -1,0 +1,138 @@
+use crate::buffer::{Buffer2D, Buffer4D};
+use crate::quantize::Quantized;
+use crate::tensor::{Tensor2D, Tensor4D};
+use core::array;
+
+/// transpose for 2D tensors. `perm` must be a permutation of `[0, 1]`
+///  output dimensions stay consistent with the permutation.
+pub fn transpose_2d<
+    T: Quantized,
+    const IN_ROWS: usize,
+    const IN_COLS: usize,
+    const OUT_ROWS: usize,
+    const OUT_COLS: usize,
+    const QUANTS: usize,
+>(
+    input: Tensor2D<T, IN_ROWS, IN_COLS, QUANTS>,
+    perm: [usize; 2],
+) -> Tensor2D<T, OUT_ROWS, OUT_COLS, QUANTS> {
+    debug_assert_eq!(OUT_ROWS, [IN_ROWS, IN_COLS][perm[0]]);
+    debug_assert_eq!(OUT_COLS, [IN_ROWS, IN_COLS][perm[1]]);
+    let out_buf = Buffer2D::from_fn(|o0, o1| {
+        let mut i = [0usize; 2];
+        i[perm[0]] = o0;
+        i[perm[1]] = o1;
+        input.buffer[(i[0], i[1])]
+    });
+    Tensor2D::new(out_buf, input.scale, input.zero_point)
+}
+
+/// transpose for 4D tensors. `perm` must be a permutation of `[0, 1, 2, 3]`
+///  output dimensions stay consistent with the permutation.
+pub fn transpose_4d<
+    T: Quantized,
+    const B: usize,
+    const R: usize,
+    const C: usize,
+    const CH: usize,
+    const OB: usize,
+    const OR: usize,
+    const OC: usize,
+    const OCH: usize,
+    const QUANTS: usize,
+>(
+    input: Tensor4D<T, B, R, C, CH, QUANTS>,
+    perm: [usize; 4],
+) -> Tensor4D<T, OB, OR, OC, OCH, QUANTS> {
+    debug_assert_eq!(OB, [B, R, C, CH][perm[0]]);
+    debug_assert_eq!(OR, [B, R, C, CH][perm[1]]);
+    debug_assert_eq!(OC, [B, R, C, CH][perm[2]]);
+    debug_assert_eq!(OCH, [B, R, C, CH][perm[3]]);
+    let out_buf: Buffer4D<T, OB, OR, OC, OCH> = array::from_fn(|o0| {
+        Buffer2D::from_fn(|o1, o2| {
+            array::from_fn(|o3| {
+                let mut i = [0usize; 4];
+                i[perm[0]] = o0;
+                i[perm[1]] = o1;
+                i[perm[2]] = o2;
+                i[perm[3]] = o3;
+                input.buffer[i[0]][(i[1], i[2])][i[3]]
+            })
+        })
+    });
+    Tensor4D::new(out_buf, input.scale, input.zero_point)
+}
+
+#[cfg(test)]
+mod tests {
+    use nalgebra::matrix;
+
+    use super::*;
+    use crate::tensor::Tensor2D;
+
+    #[test]
+    fn transpose_2d_01() {
+        let t: Tensor2D<i8, 2, 3, 1> = Tensor2D::new(
+            matrix![
+                1, 2, 3;
+                4, 5, 6
+            ],
+            [0.5],
+            [0],
+        );
+        let out: Tensor2D<i8, 3, 2, 1> = transpose_2d(t, [1, 0]);
+        assert_eq!(
+            out.buffer,
+            matrix![
+                1, 4;
+                2, 5;
+                3, 6
+            ]
+        );
+    }
+
+    #[test]
+    fn transpose_4d_identity() {
+        let t = Tensor4D::new(
+            [
+                matrix![
+                    [1, 2], [3, 4], [5, 6];
+                    [7, 8], [9, 10], [11, 12]
+                ],
+                matrix![
+                    [13, 14], [15, 16], [17, 18];
+                    [19, 20], [21, 22], [23, 24]
+                ],
+            ],
+            [1.0],
+            [0],
+        );
+        let out: Tensor4D<i8, 2, 2, 3, 2, 1> = transpose_4d(t, [0, 1, 2, 3]);
+        assert_eq!(
+            out.buffer,
+            [
+                matrix![
+                    [1, 2], [3, 4], [5, 6];
+                    [7, 8], [9, 10], [11, 12]
+                ],
+                matrix![
+                    [13, 14], [15, 16], [17, 18];
+                    [19, 20], [21, 22], [23, 24]
+                ],
+            ]
+        );
+    }
+
+    #[test]
+    fn transpose_4d_batch_channel_swap() {
+        // (B,R,C,CH) = (2,1,2,2)  ; test swaps batch (0) and channels (3) -> (2,1,2,2) with permutation [3,1,2,0]
+        let t = Tensor4D::new(
+            [matrix![[1, 2], [3, 4]], matrix![[5, 6], [7, 8]]],
+            [1.0],
+            [0],
+        );
+        let out: Tensor4D<i8, 2, 1, 2, 2, 1> = transpose_4d(t, [3, 1, 2, 0]);
+        assert_eq!(out.buffer[0], matrix![[1, 5], [3, 7]]);
+        assert_eq!(out.buffer[1], matrix![[2, 6], [4, 8]]);
+    }
+}

--- a/src/ops/transpose.rs
+++ b/src/ops/transpose.rs
@@ -3,8 +3,8 @@ use crate::quantize::Quantized;
 use crate::tensor::{Tensor2D, Tensor4D};
 use core::array;
 
-/// transpose for 2D tensors. `perm` must be a permutation of `[0, 1]`
-///  output dimensions stay consistent with the permutation.
+/// Transpose for 2D tensors. `perm` must be a permutation of `[0, 1]` output dimensions stay
+/// consistent with the permutation.
 pub fn transpose_2d<
     T: Quantized,
     const IN_ROWS: usize,
@@ -27,8 +27,8 @@ pub fn transpose_2d<
     Tensor2D::new(out_buf, input.scale, input.zero_point)
 }
 
-/// transpose for 4D tensors. `perm` must be a permutation of `[0, 1, 2, 3]`
-///  output dimensions stay consistent with the permutation.
+/// Transpose for 4D tensors. `perm` must be a permutation of `[0, 1, 2, 3]` output dimensions stay
+/// consistent with the permutation.
 pub fn transpose_4d<
     T: Quantized,
     const B: usize,


### PR DESCRIPTION
Some tflite model constructions end up with the Transpose operator
For example, it often happens when using [https://github.com/google-ai-edge/litert-torch](url) to build tflite files from torch models

Since the macros do not (yet) do any form of compilation, this probably slows down slighlty the pipeline. If done after the biggest tensor materiallized, it could also augment the peak RAM

cargo check / clippy works