### PR TITLE
Add better unimplemented information

### DIFF
--- a/microflow-macros/src/activation.rs
+++ b/microflow-macros/src/activation.rs
@@ -1,5 +1,6 @@
 use crate::tflite_flatbuffers::tflite::ActivationFunctionType;
 use proc_macro2::TokenStream as TokenStream2;
+use proc_macro_error::abort_call_site;
 use quote::{quote, ToTokens};
 
 /// Represents the tokenized version of the [`FusedActivation`].
@@ -27,7 +28,10 @@ impl From<ActivationFunctionType> for TokenFusedActivation {
             ActivationFunctionType::NONE => Self::None,
             ActivationFunctionType::RELU => Self::Relu,
             ActivationFunctionType::RELU6 => Self::Relu6,
-            _ => unimplemented!(),
+            unsupported => abort_call_site!(
+                "unsupported fused activation: {:?}. Supported activations are NONE, RELU, and RELU6",
+                unsupported
+            ),
         }
     }
 }

--- a/microflow-macros/src/lib.rs
+++ b/microflow-macros/src/lib.rs
@@ -71,17 +71,28 @@ pub fn model(args: TokenStream, item: TokenStream) -> TokenStream {
     let input_type = match input.type_() {
         TensorType::INT8 => quote!(i8),
         TensorType::UINT8 => quote!(u8),
-        _ => unimplemented!(),
+        input_type => abort_call_site!(
+            "unsupported input tensor type: {:?}. Supported input types are INT8 and UINT8",
+            input_type
+        ),
     };
     let input_tensor = match input_shape.len() {
         2 => quote!(Tensor2D),
         4 => quote!(Tensor4D),
-        _ => unimplemented!(),
+        rank => abort_call_site!(
+            "unsupported input tensor rank: {} (shape {:?}). Supported ranks are 2 and 4",
+            rank,
+            input_shape
+        ),
     };
     let input_buffer = match input_shape.len() {
         2 => quote!(Buffer2D),
         4 => quote!(Buffer4D),
-        _ => unimplemented!(),
+        rank => abort_call_site!(
+            "unsupported input tensor rank for buffer mapping: {} (shape {:?}). Supported ranks are 2 and 4",
+            rank,
+            input_shape
+        ),
     };
     let input_scale: Vec<_> = input
         .quantization()
@@ -108,7 +119,10 @@ pub fn model(args: TokenStream, item: TokenStream) -> TokenStream {
             .iter()
             .map(|e| (e as u8).to_token_stream())
             .collect(),
-        _ => unimplemented!(),
+        input_type => abort_call_site!(
+            "unsupported input zero-point tensor type: {:?}. Supported types are INT8 and UINT8",
+            input_type
+        ),
     };
 
     let operators = subgraph.operators().unwrap();
@@ -144,17 +158,28 @@ pub fn model(args: TokenStream, item: TokenStream) -> TokenStream {
     let output_type = match output.type_() {
         TensorType::INT8 => quote!(i8),
         TensorType::UINT8 => quote!(u8),
-        _ => unimplemented!(),
+        output_type => abort_call_site!(
+            "unsupported output tensor type: {:?}. Supported output types are INT8 and UINT8",
+            output_type
+        ),
     };
     let output_tensor = match output_shape.len() {
         2 => quote!(Tensor2D),
         4 => quote!(Tensor4D),
-        _ => unimplemented!(),
+        rank => abort_call_site!(
+            "unsupported output tensor rank: {} (shape {:?}). Supported ranks are 2 and 4",
+            rank,
+            output_shape
+        ),
     };
     let output_buffer = match output_shape.len() {
         2 => quote!(Buffer2D),
         4 => quote!(Buffer4D),
-        _ => unimplemented!(),
+        rank => abort_call_site!(
+            "unsupported output tensor rank for buffer mapping: {} (shape {:?}). Supported ranks are 2 and 4",
+            rank,
+            output_shape
+        ),
     };
 
     let ts = quote! {

--- a/microflow-macros/src/ops/average_pool_2d.rs
+++ b/microflow-macros/src/ops/average_pool_2d.rs
@@ -4,6 +4,7 @@ use crate::tensor::{TokenTensor4D, TokenTensorViewPadding};
 use crate::tflite_flatbuffers::tflite::{Operator, Tensor, TensorType};
 use flatbuffers::{ForwardsUOffset, Vector};
 use proc_macro2::TokenStream as TokenStream2;
+use proc_macro_error::abort_call_site;
 use quote::{quote, ToTokens};
 use simba::scalar::SupersetOf;
 
@@ -32,7 +33,10 @@ pub(crate) fn parse(
     match input_type {
         TensorType::INT8 => Box::new(TokenAveragePool2D::<i8>::new(operator, tensors)),
         TensorType::UINT8 => Box::new(TokenAveragePool2D::<u8>::new(operator, tensors)),
-        _ => unimplemented!(),
+        input_type => abort_call_site!(
+            "AveragePool2D supports only INT8/UINT8 input tensors, got {:?}",
+            input_type
+        ),
     }
 }
 

--- a/microflow-macros/src/ops/conv_2d.rs
+++ b/microflow-macros/src/ops/conv_2d.rs
@@ -6,6 +6,7 @@ use crate::tflite_flatbuffers::tflite::{Buffer, Operator, Tensor, TensorType};
 use flatbuffers::{ForwardsUOffset, Vector};
 use nalgebra::DMatrix;
 use proc_macro2::TokenStream as TokenStream2;
+use proc_macro_error::abort_call_site;
 use quote::{format_ident, quote, ToTokens};
 
 /// Represents the tokenized version of the `Conv2D` operator.
@@ -38,7 +39,10 @@ pub(crate) fn parse(
     match input_type {
         TensorType::INT8 => Box::new(TokenConv2D::<i8>::new(operator, tensors, buffers, index)),
         TensorType::UINT8 => Box::new(TokenConv2D::<u8>::new(operator, tensors, buffers, index)),
-        _ => unimplemented!(),
+        input_type => abort_call_site!(
+            "Conv2D supports only INT8/UINT8 input tensors, got {:?}",
+            input_type
+        ),
     }
 }
 

--- a/microflow-macros/src/ops/depthwise_conv_2d.rs
+++ b/microflow-macros/src/ops/depthwise_conv_2d.rs
@@ -6,6 +6,7 @@ use crate::tflite_flatbuffers::tflite::{Buffer, Operator, Tensor, TensorType};
 use flatbuffers::{ForwardsUOffset, Vector};
 use nalgebra::DMatrix;
 use proc_macro2::TokenStream as TokenStream2;
+use proc_macro_error::abort_call_site;
 use quote::{format_ident, quote, ToTokens};
 
 /// Represents the tokenized version of the `DepthwiseConv2D` operator.
@@ -42,7 +43,10 @@ pub(crate) fn parse(
         TensorType::UINT8 => Box::new(TokenDepthwiseConv2D::<u8>::new(
             operator, tensors, buffers, index,
         )),
-        _ => unimplemented!(),
+        input_type => abort_call_site!(
+            "DepthwiseConv2D supports only INT8/UINT8 input tensors, got {:?}",
+            input_type
+        ),
     }
 }
 

--- a/microflow-macros/src/ops/fully_connected.rs
+++ b/microflow-macros/src/ops/fully_connected.rs
@@ -1,6 +1,7 @@
 use flatbuffers::{ForwardsUOffset, Vector};
 use nalgebra::{convert_ref, DMatrix};
 use proc_macro2::TokenStream as TokenStream2;
+use proc_macro_error::abort_call_site;
 use quote::{format_ident, quote, ToTokens};
 use simba::scalar::SupersetOf;
 
@@ -43,7 +44,10 @@ pub(crate) fn parse(
         TensorType::UINT8 => Box::new(TokenFullyConnected::<u8>::new(
             operator, tensors, buffers, index,
         )),
-        _ => unimplemented!(),
+        input_type => abort_call_site!(
+            "FullyConnected supports only INT8/UINT8 input tensors, got {:?}",
+            input_type
+        ),
     }
 }
 

--- a/microflow-macros/src/ops/reshape.rs
+++ b/microflow-macros/src/ops/reshape.rs
@@ -1,6 +1,7 @@
 use crate::tflite_flatbuffers::tflite::{Operator, Tensor};
 use flatbuffers::{ForwardsUOffset, Vector};
 use proc_macro2::TokenStream as TokenStream2;
+use proc_macro_error::abort_call_site;
 use quote::{quote, ToTokens};
 
 /// Represents the tokenized version of the `Reshape` operator.
@@ -46,7 +47,11 @@ impl ToTokens for TokenReshape {
         let output_tensor = match output_shape.len() {
             2 => quote!(Tensor2D),
             4 => quote!(Tensor4D),
-            _ => unimplemented!(),
+            rank => abort_call_site!(
+                "Reshape supports only output tensor ranks 2 and 4, got rank {} with shape {:?}",
+                rank,
+                output_shape
+            ),
         };
 
         let ts = quote! {

--- a/microflow-macros/src/ops/softmax.rs
+++ b/microflow-macros/src/ops/softmax.rs
@@ -3,6 +3,7 @@ use crate::tensor::TokenTensor2D;
 use crate::tflite_flatbuffers::tflite::{Operator, Tensor, TensorType};
 use flatbuffers::{ForwardsUOffset, Vector};
 use proc_macro2::TokenStream as TokenStream2;
+use proc_macro_error::abort_call_site;
 use quote::{quote, ToTokens};
 
 /// Represents the tokenized version of the `Softmax` operator.
@@ -25,7 +26,10 @@ pub(crate) fn parse(
     match input_type {
         TensorType::INT8 => Box::new(TokenSoftmax::<i8>::new(operator, tensors)),
         TensorType::UINT8 => Box::new(TokenSoftmax::<u8>::new(operator, tensors)),
-        _ => unimplemented!(),
+        input_type => abort_call_site!(
+            "Softmax supports only INT8/UINT8 input tensors, got {:?}",
+            input_type
+        ),
     }
 }
 


### PR DESCRIPTION
Replaced simple `unimplemented()` calls with more detailed information.

All compile time so no change in running parts, no downside.

Cargo clippy and fmt working