### PR TITLE
feat: add pluggable backends to enable parallel inference

### DIFF
--- a/microflow-macros/src/lib.rs
+++ b/microflow-macros/src/lib.rs
@@ -12,7 +12,7 @@ use std::fs;
 
 use proc_macro2::TokenStream as TokenStream2;
 use quote::{quote, ToTokens};
-use syn::{parse_macro_input, ItemStruct};
+use syn::{parse_macro_input, ItemStruct, Path};
 
 use crate::tflite_flatbuffers::tflite::TensorType;
 use ops::*;
@@ -34,13 +34,18 @@ mod tflite_flatbuffers;
 struct Args {
     #[struct_meta(unnamed)]
     path: LitStr,
+    #[struct_meta(unnamed)]
+    backend: Option<Path>,
 }
 
 /// The entry point of MicroFlow.
 /// This attribute-like procedural macro can be placed on `structs` to implement the `predict()`
 /// function based on the given model.
-/// The macro takes as input the path of the model, which must be in the TensorFlow Lite format
-/// (`.tflite`).
+///
+/// # Arguments
+/// * `path` - Path to the `.tflite` model file (mandatory)
+/// * `backend` - Optional backend type implementing `microflow::backend::Backend`.
+///   Defaults to `microflow::backend::SequentialBackend`, which just does the jobs synchronously.
 #[proc_macro_error]
 #[proc_macro_attribute]
 pub fn model(args: TokenStream, item: TokenStream) -> TokenStream {
@@ -56,6 +61,12 @@ pub fn model(args: TokenStream, item: TokenStream) -> TokenStream {
     let model = root_as_model(&buf).unwrap_or_else(|_| {
         abort_call_site!("invalid model, please provide a valid TensorFlow Lite model")
     });
+
+    // Resolve the backend type: use the user-supplied path or fall back to SequentialBackend.
+    let backend_ty: TokenStream2 = match args.backend {
+        Some(path) => path.to_token_stream(),
+        None => quote!(microflow::backend::SequentialBackend),
+    };
 
     let ident = &item.ident;
 
@@ -136,13 +147,17 @@ pub fn model(args: TokenStream, item: TokenStream) -> TokenStream {
                 .deprecated_builtin_code() as i32,
         ) {
             BuiltinOperator::FULLY_CONNECTED => {
-                fully_connected::parse(operator, tensors, buffers, index)
+                fully_connected::parse(operator, tensors, buffers, index, &backend_ty)
             }
             BuiltinOperator::DEPTHWISE_CONV_2D => {
-                depthwise_conv_2d::parse(operator, tensors, buffers, index)
+                depthwise_conv_2d::parse(operator, tensors, buffers, index, &backend_ty)
             }
-            BuiltinOperator::CONV_2D => conv_2d::parse(operator, tensors, buffers, index),
-            BuiltinOperator::AVERAGE_POOL_2D => average_pool_2d::parse(operator, tensors),
+            BuiltinOperator::CONV_2D => {
+                conv_2d::parse(operator, tensors, buffers, index, &backend_ty)
+            }
+            BuiltinOperator::AVERAGE_POOL_2D => {
+                average_pool_2d::parse(operator, tensors, &backend_ty)
+            }
             BuiltinOperator::SOFTMAX => softmax::parse(operator, tensors),
             BuiltinOperator::RESHAPE => Box::new(reshape::parse(operator, tensors)),
             unsupported_op => abort_call_site!("unsupported operator: {:?}", unsupported_op),

--- a/microflow-macros/src/ops/average_pool_2d.rs
+++ b/microflow-macros/src/ops/average_pool_2d.rs
@@ -16,6 +16,7 @@ pub(crate) struct TokenAveragePool2D<T: TokenQuantized> {
     pub(crate) view_padding: TokenTensorViewPadding,
     pub(crate) strides: (usize, usize),
     pub(crate) constants: (f32, f32),
+    pub(crate) backend: TokenStream2,
 }
 
 /// Parses the [`TokenAveragePool2D`] struct from the given operator.
@@ -27,12 +28,13 @@ pub(crate) struct TokenAveragePool2D<T: TokenQuantized> {
 pub(crate) fn parse(
     operator: Operator,
     tensors: Vector<ForwardsUOffset<Tensor>>,
+    backend: &TokenStream2,
 ) -> Box<dyn ToTokens> {
     let inputs = operator.inputs().unwrap();
     let input_type = tensors.get(inputs.get(0) as usize).type_();
     match input_type {
-        TensorType::INT8 => Box::new(TokenAveragePool2D::<i8>::new(operator, tensors)),
-        TensorType::UINT8 => Box::new(TokenAveragePool2D::<u8>::new(operator, tensors)),
+        TensorType::INT8 => Box::new(TokenAveragePool2D::<i8>::new(operator, tensors, backend)),
+        TensorType::UINT8 => Box::new(TokenAveragePool2D::<u8>::new(operator, tensors, backend)),
         input_type => abort_call_site!(
             "AveragePool2D supports only INT8/UINT8 input tensors, got {:?}",
             input_type
@@ -47,7 +49,11 @@ impl<T: TokenQuantized> TokenAveragePool2D<T> {
     /// * `operator` - The model operator as an [`Operator`]
     /// * `tensors` - The model tensors as a [`Vector<ForwardsUOffset<Tensor>>`]
     ///
-    pub(crate) fn new(operator: Operator, tensors: Vector<ForwardsUOffset<Tensor>>) -> Self {
+    pub(crate) fn new(
+        operator: Operator,
+        tensors: Vector<ForwardsUOffset<Tensor>>,
+        backend: &TokenStream2,
+    ) -> Self {
         let inputs = operator.inputs().unwrap();
         let input = TokenTensor4D::from_empty_tensor(tensors.get(inputs.get(0) as usize));
         let output = TokenTensor4D::from_empty_tensor(
@@ -65,6 +71,7 @@ impl<T: TokenQuantized> TokenAveragePool2D<T> {
             view_padding: options.padding().into(),
             strides: (options.stride_h() as usize, options.stride_w() as usize),
             constants,
+            backend: backend.clone(),
         }
     }
 
@@ -93,10 +100,11 @@ impl<T: TokenQuantized> ToTokens for TokenAveragePool2D<T> {
         let view_padding = self.view_padding;
         let (strides_0, strides_1) = self.strides;
         let (constants_0, constants_1) = self.constants;
+        let backend = &self.backend;
 
         let ts = quote! {
             let input: microflow::tensor::Tensor4D<_, #(#output_shape),*, 1usize> =
-                microflow::ops::average_pool_2d(
+                microflow::ops::average_pool_2d::<#backend, _, _, _, _, _, _, _, _>(
                     input,
                     (nalgebra::Const::<#filter_shape_0>, nalgebra::Const::<#filter_shape_1>),
                     [#(#output_scale),*],
@@ -131,6 +139,7 @@ mod tests {
             view_padding: TokenTensorViewPadding::Same,
             strides: (1, 1),
             constants: (3., 4.),
+            backend: quote!(microflow::backend::SequentialBackend),
         }
     }
 
@@ -157,7 +166,7 @@ mod tests {
             layer.to_token_stream().to_string(),
             quote! {
                 let input: microflow::tensor::Tensor4D<_, 1usize, 2usize, 3usize, 2usize, 1usize> =
-                    microflow::ops::average_pool_2d(
+                    microflow::ops::average_pool_2d::<microflow::backend::SequentialBackend, _, _, _, _, _, _, _, _>(
                         input,
                         (nalgebra::Const::<2usize>, nalgebra::Const::<3usize>),
                         [0.1f32],

--- a/microflow-macros/src/ops/conv_2d.rs
+++ b/microflow-macros/src/ops/conv_2d.rs
@@ -18,6 +18,7 @@ pub(crate) struct TokenConv2D<T: TokenQuantized> {
     pub(crate) strides: (usize, usize),
     pub(crate) constants: (TokenBuffer2D<f32>, TokenBuffer2D<f32>),
     pub(crate) index: usize,
+    pub(crate) backend: TokenStream2,
 }
 
 /// Parses the [`TokenConv2D`] struct from the given operator.
@@ -33,12 +34,13 @@ pub(crate) fn parse(
     tensors: Vector<ForwardsUOffset<Tensor>>,
     buffers: Vector<ForwardsUOffset<Buffer>>,
     index: usize,
+    backend: &TokenStream2,
 ) -> Box<dyn ToTokens> {
     let inputs = operator.inputs().unwrap();
     let input_type = tensors.get(inputs.get(0) as usize).type_();
     match input_type {
-        TensorType::INT8 => Box::new(TokenConv2D::<i8>::new(operator, tensors, buffers, index)),
-        TensorType::UINT8 => Box::new(TokenConv2D::<u8>::new(operator, tensors, buffers, index)),
+        TensorType::INT8 => Box::new(TokenConv2D::<i8>::new(operator, tensors, buffers, index, backend)),
+        TensorType::UINT8 => Box::new(TokenConv2D::<u8>::new(operator, tensors, buffers, index, backend)),
         input_type => abort_call_site!(
             "Conv2D supports only INT8/UINT8 input tensors, got {:?}",
             input_type
@@ -60,6 +62,7 @@ impl<T: TokenQuantized> TokenConv2D<T> {
         tensors: Vector<ForwardsUOffset<Tensor>>,
         buffers: Vector<ForwardsUOffset<Buffer>>,
         index: usize,
+        backend: &TokenStream2,
     ) -> Self {
         let inputs = operator.inputs().unwrap();
         let input = TokenTensor4D::from_empty_tensor(tensors.get(inputs.get(0) as usize));
@@ -80,6 +83,7 @@ impl<T: TokenQuantized> TokenConv2D<T> {
             strides: (options.stride_h() as usize, options.stride_w() as usize),
             constants,
             index,
+            backend: backend.clone(),
         }
     }
 
@@ -126,11 +130,12 @@ impl<T: TokenQuantized> ToTokens for TokenConv2D<T> {
         let view_padding = self.view_padding;
         let (strides_0, strides_1) = self.strides;
         let (constants_0, constants_1) = &self.constants;
+        let backend = &self.backend;
 
         let ts = quote! {
             const #filters_ident: #filters_type = #filters;
             let input: microflow::tensor::Tensor4D<_, #(#output_shape),*, 1usize> =
-                microflow::ops::conv_2d(
+                microflow::ops::conv_2d::<#backend, _, _, _, _, _, _, _, _, _, _>(
                     input,
                     &#filters_ident,
                     [#(#output_scale),*],
@@ -184,6 +189,7 @@ mod tests {
                 TokenBuffer2D::from(dmatrix![33., 34.]),
             ),
             index: 0,
+            backend: quote!(microflow::backend::SequentialBackend),
         }
     }
 

--- a/microflow-macros/src/ops/depthwise_conv_2d.rs
+++ b/microflow-macros/src/ops/depthwise_conv_2d.rs
@@ -18,6 +18,7 @@ pub(crate) struct TokenDepthwiseConv2D<T: TokenQuantized> {
     pub(crate) strides: (usize, usize),
     pub(crate) constants: (TokenBuffer2D<f32>, TokenBuffer2D<f32>),
     pub(crate) index: usize,
+    pub(crate) backend: TokenStream2,
 }
 
 /// Parses the [`TokenDepthwiseConv2D`] struct from the given operator.
@@ -33,15 +34,16 @@ pub(crate) fn parse(
     tensors: Vector<ForwardsUOffset<Tensor>>,
     buffers: Vector<ForwardsUOffset<Buffer>>,
     index: usize,
+    backend: &TokenStream2,
 ) -> Box<dyn ToTokens> {
     let inputs = operator.inputs().unwrap();
     let input_type = tensors.get(inputs.get(0) as usize).type_();
     match input_type {
         TensorType::INT8 => Box::new(TokenDepthwiseConv2D::<i8>::new(
-            operator, tensors, buffers, index,
+            operator, tensors, buffers, index, backend,
         )),
         TensorType::UINT8 => Box::new(TokenDepthwiseConv2D::<u8>::new(
-            operator, tensors, buffers, index,
+            operator, tensors, buffers, index, backend,
         )),
         input_type => abort_call_site!(
             "DepthwiseConv2D supports only INT8/UINT8 input tensors, got {:?}",
@@ -64,6 +66,7 @@ impl<T: TokenQuantized> TokenDepthwiseConv2D<T> {
         tensors: Vector<ForwardsUOffset<Tensor>>,
         buffers: Vector<ForwardsUOffset<Buffer>>,
         index: usize,
+        backend: &TokenStream2,
     ) -> Self {
         let inputs = operator.inputs().unwrap();
         let input = TokenTensor4D::from_empty_tensor(tensors.get(inputs.get(0) as usize));
@@ -86,6 +89,7 @@ impl<T: TokenQuantized> TokenDepthwiseConv2D<T> {
             strides: (options.stride_h() as usize, options.stride_w() as usize),
             constants,
             index,
+            backend: backend.clone(),
         }
     }
 
@@ -132,11 +136,12 @@ impl<T: TokenQuantized> ToTokens for TokenDepthwiseConv2D<T> {
         let view_padding = self.view_padding;
         let (strides_0, strides_1) = self.strides;
         let (constants_0, constants_1) = &self.constants;
+        let backend = &self.backend;
 
         let ts = quote! {
             const #weights_ident: #weights_type = #weights;
             let input: microflow::tensor::Tensor4D<_, #(#output_shape),*, 1usize> =
-                microflow::ops::depthwise_conv_2d(
+                microflow::ops::depthwise_conv_2d::<#backend, _, _, _, _, _, _, _, _, _, _>(
                     input,
                     &#weights_ident,
                     [#(#output_scale),*],
@@ -184,6 +189,7 @@ mod tests {
                 TokenBuffer2D::from(dmatrix![21., 22.]),
             ),
             index: 0,
+            backend: quote!(microflow::backend::SequentialBackend),
         }
     }
 
@@ -223,7 +229,7 @@ mod tests {
             quote! {
                 const weights_0: microflow::tensor::Tensor4D<i8, 1usize, 2usize, 3usize, 2usize, 2usize> = #weights;
                 let input: microflow::tensor::Tensor4D<_, 1usize, 2usize, 3usize, 2usize, 1usize> =
-                    microflow::ops::depthwise_conv_2d(
+                    microflow::ops::depthwise_conv_2d::<microflow::backend::SequentialBackend, _, _, _, _, _, _, _, _, _, _>(
                         input,
                         &weights_0,
                         [0.17f32],

--- a/microflow-macros/src/ops/fully_connected.rs
+++ b/microflow-macros/src/ops/fully_connected.rs
@@ -19,6 +19,7 @@ pub(crate) struct TokenFullyConnected<T: TokenQuantized> {
     pub(crate) constants: (TokenBuffer2D<f32>, f32, TokenBuffer2D<i32>, i32),
     pub(crate) index: usize,
     pub(crate) reshape: bool,
+    pub(crate) backend: TokenStream2,
 }
 
 /// Parses the [`TokenFullyConnected`] struct from the given operator.
@@ -34,15 +35,16 @@ pub(crate) fn parse(
     tensors: Vector<ForwardsUOffset<Tensor>>,
     buffers: Vector<ForwardsUOffset<Buffer>>,
     index: usize,
+    backend: &TokenStream2,
 ) -> Box<dyn ToTokens> {
     let inputs = operator.inputs().unwrap();
     let input_type = tensors.get(inputs.get(0) as usize).type_();
     match input_type {
         TensorType::INT8 => Box::new(TokenFullyConnected::<i8>::new(
-            operator, tensors, buffers, index,
+            operator, tensors, buffers, index, backend,
         )),
         TensorType::UINT8 => Box::new(TokenFullyConnected::<u8>::new(
-            operator, tensors, buffers, index,
+            operator, tensors, buffers, index, backend,
         )),
         input_type => abort_call_site!(
             "FullyConnected supports only INT8/UINT8 input tensors, got {:?}",
@@ -65,6 +67,7 @@ impl<T: TokenQuantized> TokenFullyConnected<T> {
         tensors: Vector<ForwardsUOffset<Tensor>>,
         buffers: Vector<ForwardsUOffset<Buffer>>,
         index: usize,
+        backend: &TokenStream2,
     ) -> Self {
         let inputs = operator.inputs().unwrap();
         let input = TokenTensor2D::from_empty_tensor(tensors.get(inputs.get(0) as usize));
@@ -86,6 +89,7 @@ impl<T: TokenQuantized> TokenFullyConnected<T> {
             reshape: input.shape.len() != 2,
             constants,
             index,
+            backend: backend.clone(),
         }
     }
 
@@ -138,11 +142,12 @@ impl<T: TokenQuantized> ToTokens for TokenFullyConnected<T> {
         let output_zero_point = self.output.zero_point[0];
         let fused_activation = self.fused_activation;
         let (constants_0, constants_1, constants_2, constants_3) = &self.constants;
+        let backend = &self.backend;
 
         let ts = quote! {
             const #weights_ident: #weights_type = #weights;
             let input: microflow::tensor::Tensor2D<_, #(#output_shape),*, 1usize> =
-                microflow::ops::fully_connected(
+                microflow::ops::fully_connected::<#backend, _, _, _, _>(
                     input #reshape,
                     &#weights_ident,
                     [#output_scale],
@@ -189,6 +194,7 @@ mod tests {
             ),
             index: 0,
             reshape: false,
+            backend: quote!(microflow::backend::SequentialBackend),
         }
     }
 
@@ -234,7 +240,7 @@ mod tests {
             quote! {
                 const weights_0: microflow::tensor::Tensor2D<i8, 2usize, 3usize, 1usize> = #weights;
                 let input: microflow::tensor::Tensor2D<_, 1usize, 3usize, 1usize> =
-                    microflow::ops::fully_connected(
+                    microflow::ops::fully_connected::<microflow::backend::SequentialBackend, _, _, _, _>(
                         input,
                         &weights_0,
                         [0.9f32],

--- a/src/activation.rs
+++ b/src/activation.rs
@@ -3,6 +3,7 @@ use core::cmp::{max, min};
 use libm::expf;
 
 /// Represents the supported activation functions.
+#[derive(Copy, Clone)]
 pub enum FusedActivation {
     /// The identity activation function.
     None,

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,14 +1,44 @@
+#[derive(Clone, Copy)]
+pub struct Job{
+    #[doc(hidden)]
+    /// Type erased `worker` function
+    func: unsafe fn(*mut ()),
+    #[doc(hidden)]
+    /// Type erased argument to the `worker` function
+    arg: *mut (),
+}
+
+// Safety: Each job works on a exclusive slice of memory of a Send + Sync type
+unsafe impl Send for Job {}
+impl Job {
+
+    /// Create a new job
+    ///
+    /// # Safety
+    /// `arg` has to represent a valid argument for the unsafe `func`
+    ///
+    unsafe fn new(func: unsafe fn(*mut ()), arg: *mut ()) -> Self {
+        Job { func, arg }
+    }
+
+    /// Runs the job and consumes it
+    pub fn run(self) {
+        // SAFETY: this type cannot be constructed outside of this crate
+        // and the safety requirements are forwarded to the struct's construction
+        unsafe { (self.func)(self.arg) };
+    }
+}
 /// Trait for pluggable computation backends.
 ///
 /// A backend controls how the inner computation loops of the inference ops
 /// are scheduled.
-
+///
 /// `defer_job` is given a pointer-sized `arg`. The backend **must** ensure
 /// all deferred closures have completed before `wait` returns and before the
 /// data pointed to by `arg` is dropped or moved.
 pub trait Backend {
     /// Schedule a single unit of work.
-    fn defer_job(func: fn(usize), arg: usize);
+    fn defer_job(job: Job);
 
     /// Block until all jobs previously submitted via [`defer_job`] have completed.
     fn wait();
@@ -20,45 +50,46 @@ pub trait Backend {
     where
         F: Fn(usize, usize) -> T + Sync,
     {
-        // Safety: T is always a quantized integer type (or array thereof) for which
+        // SAFETY: T is always a quantized integer type (or array thereof) for which
         // zero bytes are a valid representation. Workers overwrite every cell before
         // `wait()` returns, so no zeroed value is ever observed.
         let mut output: [[T; ROWS]; COLS] = unsafe { core::mem::zeroed() };
-        let output_ptr = output.as_mut_ptr() as *mut T;
 
-        struct Job<'a, F, T> {
+        struct ParallelizationUnit<'a, F, T, const R: usize> {
             func: &'a F,
-            output_ptr: *mut T,
-            row: usize,
+            output_col: &'a mut [T; R],
+            col: usize,
         }
 
-        let jobs: [Job<'_, F, T>; ROWS] = core::array::from_fn(|row| Job {
-            func: &func,
-            output_ptr,
-            row,
-        });
-
-        fn worker<F, T, const R: usize, const C: usize>(argument: usize)
+        /// Runs a function on a 1 x R column
+        ///
+        /// # Safety
+        ///
+        /// The caller must ensure that `arg` represents pointer to an **initialized** `Job<'_, F, T, R>`
+        ///
+        unsafe fn worker<F, T, const R: usize>(arg: *mut ())
         where
             F: Fn(usize, usize) -> T + Sync,
             T: Send,
         {
-            // Safety: `argument` is a `&Job` erased to `usize` by the caller.
-            // `Backend::wait()` guarantees the worker finishes before `jobs` is dropped.
-            let job = unsafe { &*(argument as *const Job<'_, F, T>) };
-            for column in 0..C {
-                let value = (job.func)(job.row, column);
-                // Safety: each row is owned by exactly one job, so the column-major
-                // index `column * R + job.row` is unique across concurrent writes
-                // and no two threads alias the same address.
-                unsafe {
-                    *job.output_ptr.add(column * R + job.row) = value;
-                }
+            // SAFETY: the safety requirements are forwarded to the caller
+            let job = unsafe {(arg.cast::<ParallelizationUnit<'_, F, T, R>>()).as_mut_unchecked()};
+            for row in 0..R {
+                let value = (job.func)(job.col, row);
+                job.output_col[row] = value ;
             }
         }
 
-        for job in &jobs {
-            Self::defer_job(worker::<F, T, ROWS, COLS>, job as *const _ as usize);
+        for (c_i, column) in output.iter_mut().enumerate() {
+            let mut job = ParallelizationUnit {func: &func, output_col: column, col: c_i} ;
+            Self::defer_job(
+                unsafe {
+                    Job::new(
+                        worker::<F, T, ROWS>,
+                        (core::ptr::from_mut(&mut job)).cast()
+                    )
+                }
+            );
         }
         Self::wait();
 
@@ -72,13 +103,19 @@ pub trait Backend {
 pub struct SequentialBackend;
 
 impl Backend for SequentialBackend {
+    /// This should never be reached because all of the work is done
+    /// in `from_fn`
     #[inline(always)]
-    fn defer_job(func: fn(usize), arg: usize) {
-        func(arg);
+    fn defer_job(_job: Job) {
+        unreachable!()
     }
 
+    /// This should never be reached because all of the work is done
+    /// in `from_fn`
     #[inline(always)]
-    fn wait() {}
+    fn wait() {
+        unreachable!()
+    }
 
     #[inline(always)]
     fn from_fn<T: Send + Copy, F, const ROWS: usize, const COLS: usize>(

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,0 +1,127 @@
+/// Trait for pluggable computation backends.
+///
+/// A backend controls how the inner computation loops of the inference ops
+/// are scheduled. The default [`SequentialBackend`] runs everything inline
+/// on the calling thread.
+///
+/// # Safety contract
+/// `defer_job` is given a pointer-sized `arg`. The backend **must** ensure
+/// all deferred closures have completed before `wait` returns and before the
+/// data pointed to by `arg` is dropped or moved.
+pub trait Backend {
+    /// Schedule a single unit of work.
+    ///
+    /// Implementations may run it immediately or defer it to a thread pool.
+    fn defer_job(func: fn(usize), arg: usize);
+
+    /// Block until all jobs previously submitted via [`defer_job`] have completed.
+    fn wait();
+
+    /// Evaluates a function across a 2D grid, potentially in parallel.
+    ///
+    /// The default implementation distributes `ROWS * COLS` calls across the
+    /// backend's worker pool via [`defer_job`]. You should not need to
+    /// override this method.
+    fn from_fn<T: Send, F, const ROWS: usize, const COLS: usize>(
+        func: F,
+    ) -> crate::buffer::Buffer2D<T, ROWS, COLS>
+    where
+        F: Fn(usize, usize) -> T + Sync,
+    {
+        use core::mem::MaybeUninit;
+        use core::sync::atomic::{AtomicUsize, Ordering};
+
+        // Initialize a 2D array of MaybeUninit explicitly
+        let mut output: [[MaybeUninit<T>; ROWS]; COLS] =
+            core::array::from_fn(|_| core::array::from_fn(|_| MaybeUninit::uninit()));
+        let out_ptr = output.as_mut_ptr() as *mut MaybeUninit<T>;
+
+        struct Ctx<'a, F, T> {
+            func: &'a F,
+            out_ptr: *mut MaybeUninit<T>,
+            next_job: AtomicUsize,
+        }
+
+        let ctx = Ctx {
+            func: &func,
+            out_ptr,
+            next_job: AtomicUsize::new(0),
+        };
+
+        fn worker<F: Fn(usize, usize) -> T + Sync, T: Send, const R: usize, const C: usize>(
+            arg: usize,
+        ) {
+            let ctx = unsafe { &*(arg as *const Ctx<'_, F, T>) };
+            let total = R * C;
+            loop {
+                let idx = ctx.next_job.fetch_add(1, Ordering::Relaxed);
+                if idx >= total {
+                    break;
+                }
+                // Column-major: idx = col * R + row
+                let row = idx % R;
+                let col = idx / R;
+                let val = (ctx.func)(row, col);
+                unsafe {
+                    ctx.out_ptr.add(idx).write(MaybeUninit::new(val));
+                }
+            }
+        }
+
+        let total = ROWS * COLS;
+        for _ in 0..total {
+            Self::defer_job(worker::<F, T, ROWS, COLS>, &ctx as *const _ as usize);
+        }
+        Self::wait();
+
+        // Convert the initialized array to SMatrix ArrayStorage safely
+        unsafe {
+            let ptr = &output as *const _ as *const crate::buffer::Buffer2D<T, ROWS, COLS>;
+            let buffer = core::ptr::read(ptr);
+            // Forget the original array so its (un)initialized contents aren't dropped
+            core::mem::forget(output);
+            buffer
+        }
+    }
+}
+
+/// The default sequential backend.
+///
+/// Every job submitted via [`defer_job`] is run immediately on the calling thread.
+pub struct SequentialBackend;
+
+impl Backend for SequentialBackend {
+    #[inline(always)]
+    fn defer_job(func: fn(usize), arg: usize) {
+        func(arg);
+    }
+
+    #[inline(always)]
+    fn wait() {}
+
+    // Opt to run synchronously for minimal overhead.
+    #[inline(always)]
+    fn from_fn<T: Send, F, const ROWS: usize, const COLS: usize>(
+        func: F,
+    ) -> crate::buffer::Buffer2D<T, ROWS, COLS>
+    where
+        F: Fn(usize, usize) -> T + Sync,
+    {
+        use core::mem::MaybeUninit;
+        let mut output: [[MaybeUninit<T>; ROWS]; COLS] =
+            core::array::from_fn(|_| core::array::from_fn(|_| MaybeUninit::uninit()));
+
+        for col in 0..COLS {
+            for row in 0..ROWS {
+                output[col][row] = MaybeUninit::new(func(row, col));
+            }
+        }
+
+        unsafe {
+            let ptr = &output as *const _ as *const crate::buffer::Buffer2D<T, ROWS, COLS>;
+            let buffer = core::ptr::read(ptr);
+            core::mem::forget(output);
+            buffer
+        }
+    }
+}

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -14,69 +14,63 @@ pub trait Backend {
     fn wait();
 
     /// Evaluates a function across a 2D grid, potentially in parallel.
-    fn from_fn<T: Send, F, const ROWS: usize, const COLS: usize>(
+    fn from_fn<T: Send + Copy, F, const ROWS: usize, const COLS: usize>(
         func: F,
     ) -> crate::buffer::Buffer2D<T, ROWS, COLS>
     where
         F: Fn(usize, usize) -> T + Sync,
     {
-        use core::mem::MaybeUninit;
         use core::sync::atomic::{AtomicUsize, Ordering};
 
-        // Initialize a 2D array of MaybeUninit explicitly
-        let mut output: [[MaybeUninit<T>; ROWS]; COLS] =
-            core::array::from_fn(|_| core::array::from_fn(|_| MaybeUninit::uninit()));
-        let out_ptr = output.as_mut_ptr() as *mut MaybeUninit<T>;
+        // Safety: T is always a quantized integer type (or array thereof) for which
+        // zero bytes are a valid representation. Workers overwrite every cell before
+        // `wait()` returns, so no zeroed value is ever observed.
+        let mut output: [[T; ROWS]; COLS] = unsafe { core::mem::zeroed() };
+        let output_ptr = output.as_mut_ptr() as *mut T;
 
-        struct Ctx<'a, F, T> {
+        struct Context<'a, F, T> {
             func: &'a F,
-            out_ptr: *mut MaybeUninit<T>,
+            output_ptr: *mut T,
             next_row: AtomicUsize,
         }
 
-        let ctx = Ctx {
+        let context = Context {
             func: &func,
-            out_ptr,
+            output_ptr,
             next_row: AtomicUsize::new(0),
         };
 
-        fn worker<F, T, const R: usize, const C: usize>(arg: usize)
+        fn worker<F, T, const R: usize, const C: usize>(argument: usize)
         where
             F: Fn(usize, usize) -> T + Sync,
             T: Send,
         {
-            let ctx = unsafe { &*(arg as *const Ctx<'_, F, T>) };
+            // Safety: `argument` is a `&Context` erased to `usize` by the caller.
+            // `Backend::wait()` guarantees all workers finish before `context` is dropped.
+            let context = unsafe { &*(argument as *const Context<'_, F, T>) };
             loop {
-                let row = ctx.next_row.fetch_add(1, Ordering::Relaxed);
+                let row = context.next_row.fetch_add(1, Ordering::Relaxed);
                 if row >= R {
                     break;
                 }
-
-                // Compute a whole row (need to have bigger job for it to be worth)
-                for col in 0..C {
-                    let val = (ctx.func)(row, col);
-                    // Column-major: idx = col * R + row
-                    let idx = col * R + row;
+                for column in 0..C {
+                    let value = (context.func)(row, column);
+                    // Safety: each `row` is claimed by exactly one worker via the atomic.
+                    // The column-major index `column * R + row` is therefore unique across
+                    // all concurrent writes, so no two threads alias the same address.
                     unsafe {
-                        ctx.out_ptr.add(idx).write(MaybeUninit::new(val));
+                        *context.output_ptr.add(column * R + row) = value;
                     }
                 }
             }
         }
 
         for _ in 0..ROWS {
-            Self::defer_job(worker::<F, T, ROWS, COLS>, &ctx as *const _ as usize);
+            Self::defer_job(worker::<F, T, ROWS, COLS>, &context as *const _ as usize);
         }
         Self::wait();
 
-        // Convert the initialized array to SMatrix ArrayStorage safely
-        unsafe {
-            let ptr = &output as *const _ as *const crate::buffer::Buffer2D<T, ROWS, COLS>;
-            let buffer = core::ptr::read(ptr);
-            // Forget the original array so its (un)initialized contents aren't dropped
-            core::mem::forget(output);
-            buffer
-        }
+        crate::buffer::Buffer2D::from_array_storage(nalgebra::ArrayStorage(output))
     }
 }
 
@@ -94,29 +88,15 @@ impl Backend for SequentialBackend {
     #[inline(always)]
     fn wait() {}
 
-    // Opt to run synchronously for minimal overhead.
     #[inline(always)]
-    fn from_fn<T: Send, F, const ROWS: usize, const COLS: usize>(
+    fn from_fn<T: Send + Copy, F, const ROWS: usize, const COLS: usize>(
         func: F,
     ) -> crate::buffer::Buffer2D<T, ROWS, COLS>
     where
         F: Fn(usize, usize) -> T + Sync,
     {
-        use core::mem::MaybeUninit;
-        let mut output: [[MaybeUninit<T>; ROWS]; COLS] =
-            core::array::from_fn(|_| core::array::from_fn(|_| MaybeUninit::uninit()));
-
-        for col in 0..COLS {
-            for row in 0..ROWS {
-                output[col][row] = MaybeUninit::new(func(row, col));
-            }
-        }
-
-        unsafe {
-            let ptr = &output as *const _ as *const crate::buffer::Buffer2D<T, ROWS, COLS>;
-            let buffer = core::ptr::read(ptr);
-            core::mem::forget(output);
-            buffer
-        }
+        let output: [[T; ROWS]; COLS] =
+            core::array::from_fn(|column| core::array::from_fn(|row| func(row, column)));
+        crate::buffer::Buffer2D::from_array_storage(nalgebra::ArrayStorage(output))
     }
 }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,5 +1,5 @@
 #[derive(Clone, Copy)]
-pub struct Job{
+pub struct Job {
     #[doc(hidden)]
     /// Type erased `worker` function
     func: unsafe fn(*mut ()),
@@ -11,7 +11,6 @@ pub struct Job{
 // Safety: Each job works on a exclusive slice of memory of a Send + Sync type
 unsafe impl Send for Job {}
 impl Job {
-
     /// Create a new job
     ///
     /// # Safety
@@ -73,23 +72,23 @@ pub trait Backend {
             T: Send,
         {
             // SAFETY: the safety requirements are forwarded to the caller
-            let job = unsafe {(arg.cast::<ParallelizationUnit<'_, F, T, R>>()).as_mut_unchecked()};
+            let job =
+                unsafe { (arg.cast::<ParallelizationUnit<'_, F, T, R>>()).as_mut_unchecked() };
             for row in 0..R {
                 let value = (job.func)(job.col, row);
-                job.output_col[row] = value ;
+                job.output_col[row] = value;
             }
         }
 
         for (c_i, column) in output.iter_mut().enumerate() {
-            let mut job = ParallelizationUnit {func: &func, output_col: column, col: c_i} ;
-            Self::defer_job(
-                unsafe {
-                    Job::new(
-                        worker::<F, T, ROWS>,
-                        (core::ptr::from_mut(&mut job)).cast()
-                    )
-                }
-            );
+            let mut job = ParallelizationUnit {
+                func: &func,
+                output_col: column,
+                col: c_i,
+            };
+            Self::defer_job(unsafe {
+                Job::new(worker::<F, T, ROWS>, (core::ptr::from_mut(&mut job)).cast())
+            });
         }
         Self::wait();
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -20,53 +20,45 @@ pub trait Backend {
     where
         F: Fn(usize, usize) -> T + Sync,
     {
-        use core::sync::atomic::{AtomicUsize, Ordering};
-
         // Safety: T is always a quantized integer type (or array thereof) for which
         // zero bytes are a valid representation. Workers overwrite every cell before
         // `wait()` returns, so no zeroed value is ever observed.
         let mut output: [[T; ROWS]; COLS] = unsafe { core::mem::zeroed() };
         let output_ptr = output.as_mut_ptr() as *mut T;
 
-        struct Context<'a, F, T> {
+        struct Job<'a, F, T> {
             func: &'a F,
             output_ptr: *mut T,
-            next_row: AtomicUsize,
+            row: usize,
         }
 
-        let context = Context {
+        let jobs: [Job<'_, F, T>; ROWS] = core::array::from_fn(|row| Job {
             func: &func,
             output_ptr,
-            next_row: AtomicUsize::new(0),
-        };
+            row,
+        });
 
         fn worker<F, T, const R: usize, const C: usize>(argument: usize)
         where
             F: Fn(usize, usize) -> T + Sync,
             T: Send,
         {
-            // Safety: `argument` is a `&Context` erased to `usize` by the caller.
-            // `Backend::wait()` guarantees all workers finish before `context` is dropped.
-            let context = unsafe { &*(argument as *const Context<'_, F, T>) };
-            loop {
-                let row = context.next_row.fetch_add(1, Ordering::Relaxed);
-                if row >= R {
-                    break;
-                }
-                for column in 0..C {
-                    let value = (context.func)(row, column);
-                    // Safety: each `row` is claimed by exactly one worker via the atomic.
-                    // The column-major index `column * R + row` is therefore unique across
-                    // all concurrent writes, so no two threads alias the same address.
-                    unsafe {
-                        *context.output_ptr.add(column * R + row) = value;
-                    }
+            // Safety: `argument` is a `&Job` erased to `usize` by the caller.
+            // `Backend::wait()` guarantees the worker finishes before `jobs` is dropped.
+            let job = unsafe { &*(argument as *const Job<'_, F, T>) };
+            for column in 0..C {
+                let value = (job.func)(job.row, column);
+                // Safety: each row is owned by exactly one job, so the column-major
+                // index `column * R + job.row` is unique across concurrent writes
+                // and no two threads alias the same address.
+                unsafe {
+                    *job.output_ptr.add(column * R + job.row) = value;
                 }
             }
         }
 
-        for _ in 0..ROWS {
-            Self::defer_job(worker::<F, T, ROWS, COLS>, &context as *const _ as usize);
+        for job in &jobs {
+            Self::defer_job(worker::<F, T, ROWS, COLS>, job as *const _ as usize);
         }
         Self::wait();
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,27 +1,19 @@
 /// Trait for pluggable computation backends.
 ///
 /// A backend controls how the inner computation loops of the inference ops
-/// are scheduled. The default [`SequentialBackend`] runs everything inline
-/// on the calling thread.
-///
-/// # Safety contract
+/// are scheduled.
+
 /// `defer_job` is given a pointer-sized `arg`. The backend **must** ensure
 /// all deferred closures have completed before `wait` returns and before the
 /// data pointed to by `arg` is dropped or moved.
 pub trait Backend {
     /// Schedule a single unit of work.
-    ///
-    /// Implementations may run it immediately or defer it to a thread pool.
     fn defer_job(func: fn(usize), arg: usize);
 
     /// Block until all jobs previously submitted via [`defer_job`] have completed.
     fn wait();
 
     /// Evaluates a function across a 2D grid, potentially in parallel.
-    ///
-    /// The default implementation distributes `ROWS * COLS` calls across the
-    /// backend's worker pool via [`defer_job`]. You should not need to
-    /// override this method.
     fn from_fn<T: Send, F, const ROWS: usize, const COLS: usize>(
         func: F,
     ) -> crate::buffer::Buffer2D<T, ROWS, COLS>
@@ -39,37 +31,40 @@ pub trait Backend {
         struct Ctx<'a, F, T> {
             func: &'a F,
             out_ptr: *mut MaybeUninit<T>,
-            next_job: AtomicUsize,
+            next_row: AtomicUsize,
         }
 
         let ctx = Ctx {
             func: &func,
             out_ptr,
-            next_job: AtomicUsize::new(0),
+            next_row: AtomicUsize::new(0),
         };
 
-        fn worker<F: Fn(usize, usize) -> T + Sync, T: Send, const R: usize, const C: usize>(
-            arg: usize,
-        ) {
+        fn worker<F, T, const R: usize, const C: usize>(arg: usize)
+        where
+            F: Fn(usize, usize) -> T + Sync,
+            T: Send,
+        {
             let ctx = unsafe { &*(arg as *const Ctx<'_, F, T>) };
-            let total = R * C;
             loop {
-                let idx = ctx.next_job.fetch_add(1, Ordering::Relaxed);
-                if idx >= total {
+                let row = ctx.next_row.fetch_add(1, Ordering::Relaxed);
+                if row >= R {
                     break;
                 }
-                // Column-major: idx = col * R + row
-                let row = idx % R;
-                let col = idx / R;
-                let val = (ctx.func)(row, col);
-                unsafe {
-                    ctx.out_ptr.add(idx).write(MaybeUninit::new(val));
+
+                // Compute a whole row (need to have bigger job for it to be worth)
+                for col in 0..C {
+                    let val = (ctx.func)(row, col);
+                    // Column-major: idx = col * R + row
+                    let idx = col * R + row;
+                    unsafe {
+                        ctx.out_ptr.add(idx).write(MaybeUninit::new(val));
+                    }
                 }
             }
         }
 
-        let total = ROWS * COLS;
-        for _ in 0..total {
+        for _ in 0..ROWS {
             Self::defer_job(worker::<F, T, ROWS, COLS>, &ctx as *const _ as usize);
         }
         Self::wait();
@@ -87,7 +82,7 @@ pub trait Backend {
 
 /// The default sequential backend.
 ///
-/// Every job submitted via [`defer_job`] is run immediately on the calling thread.
+/// Every job submitted is run immediately on the calling thread.
 pub struct SequentialBackend;
 
 impl Backend for SequentialBackend {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@
 pub use microflow_macros::*;
 
 pub mod activation;
+pub mod backend;
 pub mod buffer;
 pub mod ops;
 pub mod quantize;

--- a/src/ops/average_pool_2d.rs
+++ b/src/ops/average_pool_2d.rs
@@ -5,10 +5,11 @@ use nalgebra::Const;
 use simba::scalar::SupersetOf;
 
 use crate::activation::{relu, relu6, FusedActivation};
-use crate::buffer::Buffer2D;
+use crate::backend::Backend;
 use crate::quantize::Quantized;
 use crate::tensor::{Tensor4D, TensorView, TensorViewPadding};
 
+#[derive(Copy, Clone)]
 pub struct AveragePool2DOptions {
     pub fused_activation: FusedActivation,
     pub view_padding: TensorViewPadding,
@@ -27,6 +28,7 @@ pub struct AveragePool2DOptions {
 /// * `constants` - Constant values coming from the pre-processing phase
 ///
 pub fn average_pool_2d<
+    B: Backend,
     T: Quantized,
     const INPUT_ROWS: usize,
     const INPUT_COLS: usize,
@@ -43,7 +45,7 @@ pub fn average_pool_2d<
     options: AveragePool2DOptions,
     constants: (f32, f32),
 ) -> Tensor4D<T, 1, OUTPUT_ROWS, OUTPUT_COLS, INPUT_CHANS, 1> {
-    let output = [Buffer2D::from_fn(|i, j| {
+    let output = [B::from_fn(|i, j| {
         // Extract the view using the view extraction algorithm
         let view: TensorView<T, FILTER_ROWS, FILTER_COLS, INPUT_CHANS> =
             input.view((i, j), 0, options.view_padding, options.strides);
@@ -68,6 +70,8 @@ pub fn average_pool_2d<
 #[cfg(test)]
 mod tests {
     use nalgebra::matrix;
+
+    use crate::backend::SequentialBackend;
 
     use super::*;
 
@@ -100,7 +104,7 @@ mod tests {
     #[test]
     fn average_pool_2d_layer() {
         assert_eq!(
-            average_pool_2d(
+            average_pool_2d::<SequentialBackend, _, _, _, _, _, _, _, _>(
                 INPUT,
                 FILTER_SHAPE,
                 OUTPUT_SCALE,

--- a/src/ops/conv_2d.rs
+++ b/src/ops/conv_2d.rs
@@ -4,6 +4,7 @@ use libm::roundf;
 use simba::scalar::SupersetOf;
 
 use crate::activation::{relu, relu6, FusedActivation};
+use crate::backend::Backend;
 use crate::buffer::Buffer2D;
 use crate::quantize::Quantized;
 use crate::tensor::{Tensor4D, TensorView, TensorViewPadding};
@@ -26,6 +27,7 @@ pub struct Conv2DOptions {
 /// * `constants` - Constant values coming from the pre-processing phase
 ///
 pub fn conv_2d<
+    B: Backend,
     T: Quantized,
     const INPUT_ROWS: usize,
     const INPUT_COLS: usize,
@@ -47,7 +49,7 @@ pub fn conv_2d<
         Buffer2D<f32, FILTERS_QUANTS, 1>,
     ),
 ) -> Tensor4D<T, 1, OUTPUT_ROWS, OUTPUT_COLS, FILTERS_BATCHES, 1> {
-    let output = [Buffer2D::from_fn(|i, j| {
+    let output = [B::from_fn(|i, j| {
         // Extract the view using the view extraction algorithm
         let view: TensorView<T, FILTERS_ROWS, FILTERS_COLS, INPUT_CHANS> =
             input.view((i, j), 0, options.view_padding, options.strides);
@@ -111,6 +113,7 @@ pub fn conv_2d<
 mod tests {
     use nalgebra::matrix;
 
+    use crate::backend::SequentialBackend;
     use crate::tensor::Tensor2D;
 
     use super::*;
@@ -168,7 +171,7 @@ mod tests {
     #[test]
     fn conv_2d_layer() {
         assert_eq!(
-            conv_2d(
+            conv_2d::<SequentialBackend, _, _, _, _, _, _, _, _, _, _>(
                 INPUT,
                 &FILTERS,
                 OUTPUT_SCALE,

--- a/src/ops/depthwise_conv_2d.rs
+++ b/src/ops/depthwise_conv_2d.rs
@@ -4,10 +4,12 @@ use libm::roundf;
 use simba::scalar::SupersetOf;
 
 use crate::activation::{relu, relu6, FusedActivation};
+use crate::backend::Backend;
 use crate::buffer::Buffer2D;
 use crate::quantize::Quantized;
 use crate::tensor::{Tensor4D, TensorView, TensorViewPadding};
 
+#[derive(Copy, Clone)]
 pub struct DepthwiseConv2DOptions {
     pub fused_activation: FusedActivation,
     pub view_padding: TensorViewPadding,
@@ -26,6 +28,7 @@ pub struct DepthwiseConv2DOptions {
 /// * `constants` - Constant values coming from the pre-processing phase
 ///
 pub fn depthwise_conv_2d<
+    B: Backend,
     T: Quantized,
     const INPUT_ROWS: usize,
     const INPUT_COLS: usize,
@@ -47,7 +50,7 @@ pub fn depthwise_conv_2d<
         Buffer2D<f32, WEIGHTS_QUANTS, 1>,
     ),
 ) -> Tensor4D<T, 1, OUTPUT_ROWS, OUTPUT_COLS, WEIGHTS_CHANS, 1> {
-    let output = [Buffer2D::from_fn(|i, j| {
+    let output = [B::from_fn(|i, j| {
         // Extract the view using the view extraction algorithm
         let view: TensorView<T, WEIGHTS_ROWS, WEIGHTS_COLS, INPUT_CHANS> =
             input.view((i, j), 0, options.view_padding, options.strides);
@@ -108,6 +111,7 @@ pub fn depthwise_conv_2d<
 mod tests {
     use nalgebra::matrix;
 
+    use crate::backend::SequentialBackend;
     use crate::tensor::Tensor2D;
 
     use super::*;
@@ -159,7 +163,7 @@ mod tests {
     #[test]
     fn depthwise_conv_2d_layer() {
         assert_eq!(
-            depthwise_conv_2d(
+            depthwise_conv_2d::<SequentialBackend, _, _, _, _, _, _, _, _, _, _>(
                 INPUT,
                 &WEIGHTS,
                 OUTPUT_SCALE,

--- a/src/ops/fully_connected.rs
+++ b/src/ops/fully_connected.rs
@@ -2,10 +2,12 @@ use libm::roundf;
 use simba::scalar::SupersetOf;
 
 use crate::activation::{relu, relu6, FusedActivation};
+use crate::backend::Backend;
 use crate::buffer::Buffer2D;
 use crate::quantize::Quantized;
 use crate::tensor::Tensor2D;
 
+#[derive(Copy, Clone)]
 pub struct FullyConnectedOptions {
     pub fused_activation: FusedActivation,
 }
@@ -22,6 +24,7 @@ pub struct FullyConnectedOptions {
 /// * `constants` - Constant values coming from the pre-processing phase
 ///
 pub fn fully_connected<
+    B: Backend,
     T: Quantized,
     const INPUT_ROWS: usize,
     const INPUT_COLS: usize,
@@ -64,7 +67,7 @@ pub fn fully_connected<
         }),
     );
     // Combine the constant values and the variants to obtain the output
-    let output = Buffer2D::from_fn(|i, j| {
+    let output = B::from_fn(|i, j| {
         let y = T::from_superset_unchecked(&roundf(
             f32::from_subset(&output_zero_point[0])
                 + constants.0[j]
@@ -84,6 +87,8 @@ pub fn fully_connected<
 #[cfg(test)]
 mod tests {
     use nalgebra::matrix;
+
+    use crate::backend::SequentialBackend;
 
     use super::*;
 
@@ -134,7 +139,7 @@ mod tests {
     #[test]
     fn fully_connected_layer() {
         assert_eq!(
-            fully_connected(
+            fully_connected::<SequentialBackend, _, _, _, _>(
                 INPUT,
                 &WEIGHTS,
                 OUTPUT_SCALE,

--- a/src/quantize.rs
+++ b/src/quantize.rs
@@ -3,8 +3,8 @@ use nalgebra::Scalar;
 use simba::scalar::{SubsetOf, SupersetOf};
 
 /// Represents the trait to constrain a type to be quantized.
-pub trait Quantized: Scalar + Copy + Ord + SubsetOf<i32> + SubsetOf<f32> {}
-impl<T: Scalar + Copy + Ord + SubsetOf<i32> + SubsetOf<f32>> Quantized for T {}
+pub trait Quantized: Scalar + Copy + Ord + SubsetOf<i32> + SubsetOf<f32> + Send + Sync {}
+impl<T: Scalar + Copy + Ord + SubsetOf<i32> + SubsetOf<f32> + Send + Sync> Quantized for T {}
 
 /// Performs quantization on the given floating-point input.
 ///

--- a/src/quantize.rs
+++ b/src/quantize.rs
@@ -3,8 +3,11 @@ use nalgebra::Scalar;
 use simba::scalar::{SubsetOf, SupersetOf};
 
 /// Represents the trait to constrain a type to be quantized.
-pub trait Quantized: Scalar + Copy + Ord + SubsetOf<i32> + SubsetOf<f32> + Send + Sync {}
-impl<T: Scalar + Copy + Ord + SubsetOf<i32> + SubsetOf<f32> + Send + Sync> Quantized for T {}
+pub trait Quantized: Scalar + Copy + Ord + SubsetOf<i32> + SubsetOf<f32> + Send + Sync + Default {}
+impl<T: Scalar + Copy + Ord + SubsetOf<i32> + SubsetOf<f32> + Send + Sync + Default> Quantized
+    for T
+{
+}
 
 /// Performs quantization on the given floating-point input.
 ///


### PR DESCRIPTION
This PR adds a `Backend` trait to Microflow that allows downstream users to parallelize inference and a `backend` argument to the `model` proc-macro. 

This PR implements a Sequential Backend and uses column parallelization by default which makes the most sense as `nalgebra` stores its matrices with column-major indices.

The work presented in this PR is joint work between @NathanDuboisset and me. 